### PR TITLE
Correct Name of TradingEngineServerConfiguration in TradingEngineServer

### DIFF
--- a/src/TradingEngine/TradingEngineServer.cs
+++ b/src/TradingEngine/TradingEngineServer.cs
@@ -15,10 +15,10 @@ namespace TradingEngine.Core
 {
     class TradingEngineServer : BackgroundService, ITradingEngine
     {
-        private readonly IOptions<TradingEngineConfiguration> _engineConfiguration;
+        private readonly IOptions<TradingEngineServerConfiguration> _engineConfiguration;
         private readonly ILogger<TradingEngineServer> _logger;
 
-        public TradingEngineServer(IOptions<TradingEngineConfiguration> engineConfiguration,
+        public TradingEngineServer(IOptions<TradingEngineServerConfiguration> engineConfiguration,
             ILogger<TradingEngineServer> logger)
         {
             _engineConfiguration = engineConfiguration ?? throw new ArgumentNullException(nameof(engineConfiguration));


### PR DESCRIPTION
For some reason I forgot to change the name of the TradingEngineServerConfiguration in TradingEngineServer. Here I'm just using the class's corrected name. I thought I used VS's rename feature, which should have taken care of this name change in TradingEngineServer for me (replacing the name in all associated files where this type exists).