### PR TITLE
Add Event Time to Fills and Trades

### DIFF
--- a/src/FillsCS/Fill.cs
+++ b/src/FillsCS/Fill.cs
@@ -8,6 +8,10 @@ namespace TradingEngineServer.Fills
     public class Fill
     {
         /// <summary>
+        /// Initial processing time (in UTC) of the event that lead to the fill.
+        /// </summary>
+        public DateTime EventTime { get; set; }
+        /// <summary>
         /// Order that was fully or partially filled.
         /// </summary>
         public IOrderCore OrderBase { get; set; }

--- a/src/OrderbookCS/MatchingAlgorithm/FifoMatchingAlgorithm.cs
+++ b/src/OrderbookCS/MatchingAlgorithm/FifoMatchingAlgorithm.cs
@@ -13,11 +13,15 @@ namespace TradingEngineServer.Orderbook.MatchingAlgorithm
 
         public MatchResult Match(IEnumerable<OrderbookEntry> bids, IEnumerable<OrderbookEntry> asks)
         {
+            var eventTime = DateTime.UtcNow;
             var matchResult = new MatchResult();
+
             if (!bids.Any() || !asks.Any())
                 return matchResult; // Can't match without both sides.
+
             OrderbookEntry orderToMatchBid = bids.First();
             OrderbookEntry orderToMatchAsk = asks.First();
+            
             do
             {
                 if (orderToMatchAsk.Current.Price > orderToMatchBid.Current.Price)
@@ -40,7 +44,7 @@ namespace TradingEngineServer.Orderbook.MatchingAlgorithm
                 orderToMatchAsk.Current.DecreaseQuantity(fillQuantity);
 
                 var tradeResult = TradeUtilities.CreateTradeAndFills(orderToMatchBid.Current, orderToMatchAsk.Current,
-                    fillQuantity, FillAllocationAlgorithm.Fifo);
+                    fillQuantity, FillAllocationAlgorithm.Fifo, eventTime);
                 matchResult.AddTradeResult(tradeResult);
 
                 // Lets move on!

--- a/src/OrderbookCS/MatchingAlgorithm/ProRataMatchingAlgorithm.cs
+++ b/src/OrderbookCS/MatchingAlgorithm/ProRataMatchingAlgorithm.cs
@@ -14,6 +14,7 @@ namespace TradingEngineServer.Orderbook.MatchingAlgorithm
 
         public MatchResult Match(IEnumerable<OrderbookEntry> bids, IEnumerable<OrderbookEntry> asks)
         {
+            var eventTime = DateTime.UtcNow;
             var matchResult = new MatchResult();
 
             if (!bids.Any() || !asks.Any())
@@ -32,6 +33,7 @@ namespace TradingEngineServer.Orderbook.MatchingAlgorithm
 
             OrderbookEntry orderToMatchBid = bidIterator.CurrentItemOrDefault();
             OrderbookEntry orderToMatchAsk = askIterator.CurrentItemOrDefault();
+            
             do
             {
                 if (orderToMatchAsk.Current.Price > orderToMatchBid.Current.Price)
@@ -56,7 +58,7 @@ namespace TradingEngineServer.Orderbook.MatchingAlgorithm
                 orderToMatchAsk.Current.DecreaseQuantity(fillQuantity);
 
                 var tradeResult = TradeUtilities.CreateTradeAndFills(orderToMatchBid.Current, orderToMatchAsk.Current,
-                    fillQuantity, FillAllocationAlgorithm.ProRata);
+                    fillQuantity, FillAllocationAlgorithm.ProRata, eventTime);
                 matchResult.AddTradeResult(tradeResult);
 
                 if (tradeResult.BuyFill.IsCompleteFill)

--- a/src/OrderbookCSTest/CoreOrderbookTests.cs
+++ b/src/OrderbookCSTest/CoreOrderbookTests.cs
@@ -7,7 +7,7 @@ using TradingEngineServer.Rejects;
 namespace OrderbookCSTest
 {
     [TestClass]
-    public class OrderbookTests
+    public class CoreOrderbookTests
     {
         [TestMethod]
         public void Orderbook_AddSingleOrder_Success()

--- a/src/TradesCS/Trade.cs
+++ b/src/TradesCS/Trade.cs
@@ -6,6 +6,7 @@ namespace TradingEngineServer.Trades
 {
     public class Trade
     {
+        public DateTime EventTime { get; set; }
         public int SecurityId { get; set; }
         public long Price { get; set; }
         public uint Quantity { get; set; }

--- a/src/TradesCS/TradeUtilities.cs
+++ b/src/TradesCS/TradeUtilities.cs
@@ -8,15 +8,16 @@ namespace TradingEngineServer.Trades
 {
     public sealed class TradeUtilities
     {
-        public static TradeResult CreateTradeAndFills(Order bidOrder, Order askOrder, uint fillQuantity, FillAllocationAlgorithm fillAlocAlgo)
+        public static TradeResult CreateTradeAndFills(Order bidOrder, Order askOrder, 
+            uint fillQuantity, FillAllocationAlgorithm fillAlocAlgo, DateTime eventTime)
         {
-            var tradeTime = DateTime.UtcNow;
             var tradeNumber = TradeIdGenerator.GenerateTradeId();
             var fillsIds = GetFillIds(tradeNumber);
-            var executionId = GetTradeExecutionId(tradeTime, tradeNumber);
+            var executionId = GetTradeExecutionId(eventTime, tradeNumber);
 
             var buyFill = new Fill()
             {
+                EventTime = eventTime,
                 FillAllocationAlgorithm = fillAlocAlgo,
                 FillQuantity = fillQuantity,
                 IsCompleteFill = bidOrder.CurrentQuantity == 0,
@@ -27,6 +28,7 @@ namespace TradingEngineServer.Trades
 
             var askFill = new Fill()
             {
+                EventTime = eventTime,
                 FillAllocationAlgorithm = fillAlocAlgo,
                 FillQuantity = fillQuantity,
                 IsCompleteFill = askOrder.CurrentQuantity == 0,
@@ -37,6 +39,7 @@ namespace TradingEngineServer.Trades
 
             var trade = new Trade()
             {
+                EventTime = eventTime,
                 SecurityId = bidOrder.SecurityId,
                 Price = bidOrder.Price,
                 Quantity = fillQuantity,


### PR DESCRIPTION
**Related Changes**

Given that all trading is order-action driven, we should add event time to the result of order actions for the purpose of tracking all actions that belong to a single event. Traders will expect to see the time at which their match happened, and the times associated trades and fills were processed.

You can read more about event time [here](https://www.cmegroup.com/confluence/display/EPICSANDBOX/MDP+3.0+-+Event+Based+Market+Data+Messaging).

**Unrelated Changes**

Change _OrderbookTests_ to _CoreOrderbookTests_